### PR TITLE
Create contributors/index.html

### DIFF
--- a/contributors/index.html
+++ b/contributors/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <link rel="icon" href="favicon.ico">

--- a/contributors/index.html
+++ b/contributors/index.html
@@ -1,0 +1,24 @@
+<html lang="en">
+<head>
+  <link rel="icon" href="favicon.ico">
+  <link rel="canonical" href="https://github.com/jirastopwatch/jirastopwatch/graphs/contributors"/>
+
+  <meta http-equiv="refresh" content="0; url=https://github.com/jirastopwatch/jirastopwatch/graphs/contributors" />
+  <meta name="generator" content="HTML Tidy for HTML5 for Linux version 5.6.0">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <meta name="author" content="">
+
+  <title>JIRA StopWatch Contributors</title>
+  <script type="text/javascript">
+    window.location.href = "https://github.com/jirastopwatch/jirastopwatch/graphs/contributors"
+  </script>
+</head>
+<body>
+  <p>
+    If you are not redirected automatically, follow <a href='https://github.com/jirastopwatch/jirastopwatch/graphs/contributors'>this link to GitHub.com</a>.
+  </p>
+</body>
+</html>


### PR DESCRIPTION
This will redirect https://jirastopwatch.github.io/contributors to the contributors graph, as a shortcut, possibly with future expansion.
