### PR TITLE
Make changelog metadata title hidden from main page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,7 +57,7 @@ jobs:
           TEMPLATE: |
             ---
             lang: en
-            title: Changelog
+            title-meta: Changelog
             ...
 
             # Change Log


### PR DESCRIPTION
This prevents the double title.