### PR TITLE
Add main to `branches-ignore` for build event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ run-name: "Build GitHub Pages"
 on:
   workflow_call:
   push:
+    branches-ignore: [main]
   pull_request:
     branches: [main]
     types:


### PR DESCRIPTION
Pushes to main are built as part of the deployment workflow so building main is redundant anyway.