### PR TITLE
Simplify `/contributors` redirect

### DIFF
--- a/contributors.redirect
+++ b/contributors.redirect
@@ -1,1 +1,1 @@
-https://github.com/jirastopwatch/jirastopwatch/graphs/contributors
+https://github.com/jirastopwatch/jirastopwatch/contributors


### PR DESCRIPTION
Github already redirects `<org>/<repo>/contributors` to `<org>/<repo>/graphs/contributors`, so  the redirect here can be simplified.