### PR TITLE
Update website deployment to accept release dispatch events

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,11 +2,18 @@ name: "Deploy GitHub Pages"
 run-name: "Deploy GitHub Pages"
 
 on:
-  workflow_dispatch:
+
   schedule:
     - cron: '0 0 1 * *'
+
   push:
     branches: [main]
+
+  workflow_dispatch:
+
+  repository_dispatch:
+    types:
+      - release
 
 permissions:
   contents: read
@@ -18,10 +25,13 @@ env:
 
 jobs:
   build:
+    if: github.ref_name == 'main' # Only build the main branch, otherwise something has gone wrong!
+    name: "Build GitHub Pages"
     uses: ./.github/workflows/build.yml
 
   deploy:
-    if: github.ref_name == 'main'
+    if: github.event_name != 'repository_dispatch' || github.client_payload.repository == 'jirastopwatch/jirastopwatch' # Only deploy from dispatch events from the main repo, (or from events in this repo), otherwise ignore.
+    name: "Deploy GitHub Pages"
     needs: build
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This will trigger the deployment when a release is created in the main repo (where JiraStopWatch is actually built). So when a new version is available, the website will automatically update.

<!-- LIST CHANGES HERE -->
